### PR TITLE
Fitness function zero avoidance

### DIFF
--- a/src/Individual.java
+++ b/src/Individual.java
@@ -37,7 +37,7 @@ public class Individual implements Comparable<Individual>{
         fitness = 0.0;
         int i = 0;
         for(Integer g : genotype){
-            fitness += (Math.pow(dataFlow.get(i), correctionRate.get(g)) / correctionCost.get(g));
+            fitness += (Math.pow((dataFlow.get(i) + 1), correctionRate.get(g)) / correctionCost.get(g));
             i++;
         }
     }

--- a/tests/IndividualTest.java
+++ b/tests/IndividualTest.java
@@ -55,7 +55,7 @@ public class IndividualTest {
     public void fitnessValidation() {
         Individual individual = new Individual(newGenotype, dataFlow, correctionRate, correctionCost);
 
-        Assert.assertEquals(46.916, individual.getFitness(), 0.001);
+        Assert.assertEquals(364.333, individual.getFitness(), 0.001);
     }
 
     @Test


### PR DESCRIPTION
All data flows are incremented by one to avoid the case of a buffer that do not has any data flow. So, data flow can be divisible by the correction cost without any problems.

Commit: Fix

TaskNumber: #14